### PR TITLE
Handle read_pairs_table errors without exiting

### DIFF
--- a/src/kinship_vis/cli.py
+++ b/src/kinship_vis/cli.py
@@ -1,6 +1,7 @@
 
 from __future__ import annotations
 import argparse
+import sys
 import networkx as nx
 from .io import read_pairs_table, read_haplogroups, read_samplesheet
 from .graph import build_graph
@@ -36,7 +37,11 @@ def _cli() -> argparse.Namespace:
 
 def main():
     a = _cli()
-    df = read_pairs_table(a.genome_file)
+    try:
+        df = read_pairs_table(a.genome_file)
+    except (FileNotFoundError, ValueError) as e:
+        print(f"[ERROR] {e}", file=sys.stderr)
+        sys.exit(1)
     G = build_graph(df, a.threshold1, a.threshold2, a.z1_threshold,
                     a.max_degree_fraction, a.drop_below_threshold2, a.verbose)
     if G.number_of_edges() == 0:

--- a/src/kinship_vis/io.py
+++ b/src/kinship_vis/io.py
@@ -1,6 +1,6 @@
 
 from __future__ import annotations
-import os, sys
+import os
 import pandas as pd
 
 def _read_table(path: str, **kwargs) -> pd.DataFrame:
@@ -16,7 +16,7 @@ def read_pairs_table(fp: str) -> pd.DataFrame:
     """
     # Allow URLs and local files; only error if it's a local path that doesn't exist
     if not (fp.startswith("http://") or fp.startswith("https://")) and not os.path.exists(fp):
-        sys.exit(f"[ERROR] genome/kinship file not found: {fp}")
+        raise FileNotFoundError(f"genome/kinship file not found: {fp}")
     df = _read_table(fp, sep=r"\s+", dtype=str)
     cols = set(df.columns)
 
@@ -34,7 +34,7 @@ def read_pairs_table(fp: str) -> pd.DataFrame:
         out["Z1"] = 0.0  # KING lacks Z1
         return out[["IID1","IID2","PI_HAT","Z1"]]
 
-    sys.exit("[ERROR] Unrecognized pairs file; expected PLINK .genome (IID1 IID2 PI_HAT [Z1]) or KING .kin0 (ID1 ID2 Kinship).")
+    raise ValueError("Unrecognized pairs file; expected PLINK .genome (IID1 IID2 PI_HAT [Z1]) or KING .kin0 (ID1 ID2 Kinship).")
 
 def read_haplogroups(fp: str):
     """Read two-column file: <sample><tab><haplogroup> (no header). Returns Series index=sample."""

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,5 +1,6 @@
 
 import io, pandas as pd
+import pytest
 from kinship_vis.graph import build_graph
 from kinship_vis.io import read_pairs_table
 
@@ -18,3 +19,15 @@ def test_read_king_kin0(tmp_path):
     df = read_pairs_table(str(kin_path))
     assert {"IID1","IID2","PI_HAT","Z1"}.issubset(df.columns)
     assert df["PI_HAT"].iloc[0] == 1.0
+
+
+def test_read_pairs_missing_file():
+    with pytest.raises(FileNotFoundError):
+        read_pairs_table("/no/such/file")
+
+
+def test_read_pairs_bad_format(tmp_path):
+    bad = tmp_path / "bad.txt"
+    bad.write_text("a b c\n1 2 3\n", encoding="utf-8")
+    with pytest.raises(ValueError):
+        read_pairs_table(str(bad))


### PR DESCRIPTION
## Summary
- raise FileNotFoundError and ValueError from `read_pairs_table`
- catch those exceptions in the CLI and display friendly messages
- add tests for invalid path and bad pair table format

## Testing
- ⚠️ `pip install -e .` (failed: Could not find a version that satisfies the requirement hatchling>=1.26)
- ✅ `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1bb65d3cc832682a663f75c7c8194