### PR TITLE
Reuse _read_table in IO helpers

### DIFF
--- a/src/kinship_vis/io.py
+++ b/src/kinship_vis/io.py
@@ -38,14 +38,20 @@ def read_pairs_table(fp: str) -> pd.DataFrame:
 
 def read_haplogroups(fp: str):
     """Read two-column file: <sample><tab><haplogroup> (no header). Returns Series index=sample."""
-    s = pd.read_csv(fp, sep=None, engine="python", header=None, usecols=[0,1], names=["sample","hg"], dtype=str)
+    s = _read_table(
+        fp,
+        header=None,
+        usecols=[0, 1],
+        names=["sample", "hg"],
+        dtype=str,
+    )
     s["sample"] = s["sample"].astype(str).str.strip()
     s["hg"] = s["hg"].astype(str).str.strip()
     return s.set_index("sample")["hg"]
 
 def read_samplesheet(fp: str) -> pd.DataFrame:
     """Read a samplesheet that must contain a 'sample_id' column; trims whitespace for object columns."""
-    df = pd.read_csv(fp, sep=None, engine="python", dtype=str)
+    df = _read_table(fp, dtype=str)
     if "sample_id" not in df.columns:
         raise ValueError("samplesheet must contain column 'sample_id'")
     return df.apply(lambda c: c.str.strip() if c.dtype == "object" else c)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,0 +1,19 @@
+from kinship_vis.io import read_haplogroups, read_samplesheet
+
+
+def test_read_haplogroups_whitespace(tmp_path):
+    txt = " A   H1 \nB\tH2\nC   H3  extra\n"
+    path = tmp_path / "hg.txt"
+    path.write_text(txt, encoding="utf-8")
+    s = read_haplogroups(str(path))
+    assert s.to_dict() == {"A": "H1", "B": "H2", "C": "H3"}
+
+
+def test_read_samplesheet_whitespace(tmp_path):
+    txt = """sample_id cohort note\nA   grp1   foo  \nB\tgrp2\tbar \n"""
+    path = tmp_path / "samples.txt"
+    path.write_text(txt, encoding="utf-8")
+    df = read_samplesheet(str(path))
+    assert list(df.columns) == ["sample_id", "cohort", "note"]
+    assert df.loc[0, "note"] == "foo"
+    assert df.loc[1, "note"] == "bar"


### PR DESCRIPTION
## Summary
- Use shared `_read_table` in `read_haplogroups` and `read_samplesheet` for consistent whitespace handling
- Add tests ensuring parsers trim fields and accept mixed spaces/tabs

## Testing
- `pip install -e .` *(fails: Could not find a version that satisfies the requirement hatchling>=1.26)*
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1bc674b348326bd4bac2d017120e5