### PR TITLE
Add haplogroup legend to interactive HTML plots

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 Visualize pairwise kinship results (PLINK `.genome` or KING `.kin0`) as component graphs with:
 - Static PNG/TIFF **(Matplotlib)** — edges colored by kinship class, nodes filled by MT haplogroup and outlined by Y haplogroup.
-- Interactive HTML **(Plotly)** — same color scheme, hover tooltips, optional legend.
+- Interactive HTML **(Plotly)** — same color scheme, hover tooltips, optional legend including haplogroups.
 
 ## Installation
 ```bash
@@ -40,7 +40,7 @@ kinship-vis results.genome \
   --samplesheet samples.tsv --label-col short_id \
   --haplogroup-Y y_hg.hg \
   --haplogroup-MT mt_hg.txt \
-  --output out/kinship --legend
+  --output out/kinship --legend  # adds legend for edges and haplogroups
 ```
 
 ### How to obtain haplogroups (suggested tools)

--- a/src/kinship_vis/viz.py
+++ b/src/kinship_vis/viz.py
@@ -120,7 +120,34 @@ def plot_html(G, comp, cid, args, attrs):
         marker=dict(size=int(args.node_size_html), color=fill, line=dict(width=2, color=border)),
         showlegend=False)
 
-    fig = go.Figure(edge_traces + [node],
+    legend_traces = []
+    if args.legend:
+        mt_colors: Dict[str, Tuple[float, float, float]] = {}
+        y_colors: Dict[str, Tuple[float, float, float]] = {}
+        for n in sg.nodes():
+            mt_colors[attrs[n]["hgMT"]] = attrs[n]["colMT"]
+            y_colors[attrs[n]["hgY"]] = attrs[n]["colY"]
+
+        legend_traces.append(go.Scatter(x=[None], y=[None], mode="markers",
+                                        marker=dict(size=0, color="rgba(0,0,0,0)"),
+                                        name="MT haplogroups", hoverinfo="none"))
+        for h in sorted(mt_colors):
+            legend_traces.append(go.Scatter(x=[None], y=[None], mode="markers",
+                                            marker=dict(size=int(args.node_size_html),
+                                                        color=mt_colors[h],
+                                                        line=dict(width=1, color="black")),
+                                            name=h, hoverinfo="none"))
+        legend_traces.append(go.Scatter(x=[None], y=[None], mode="markers",
+                                        marker=dict(size=0, color="rgba(0,0,0,0)"),
+                                        name="Y haplogroups", hoverinfo="none"))
+        for h in sorted(y_colors):
+            legend_traces.append(go.Scatter(x=[None], y=[None], mode="markers",
+                                            marker=dict(size=int(args.node_size_html),
+                                                        color="white",
+                                                        line=dict(width=2, color=y_colors[h])),
+                                            name=h, hoverinfo="none"))
+
+    fig = go.Figure(edge_traces + legend_traces + [node],
         layout=go.Layout(title=f"Kinship component {cid}",
                          paper_bgcolor="white", plot_bgcolor="white",
                          xaxis=dict(visible=False), yaxis=dict(visible=False),


### PR DESCRIPTION
## Summary
- add Y/MT haplogroup legend items to Plotly HTML output
- document haplogroup legend in README

## Testing
- `PYTHONPATH=src pytest`
- `PYTHONPATH=src python -m kinship_vis.cli examples/G1000_31S.genome --haplogroup-Y examples/G1000_31S_chrY.hapresult.hg --haplogroup-MT examples/G1000_31S_chrMT_haplogrep.txt --output out/kinship --legend`


------
https://chatgpt.com/codex/tasks/task_e_68b1c07a3dd08326ab5218e5b424045a