### PR TITLE
Ensure tests import src package

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = src


### PR DESCRIPTION
## Summary
- add `pytest.ini` to point pytest's `pythonpath` at the `src` directory, allowing `kinship_vis` to be imported during tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1fc4919188326b8852331a310766a