### PR TITLE
Pin numpy below version 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ Visualize pairwise kinship results (PLINK `.genome` or KING `.kin0`) as componen
 pip install kinship-vis
 ```
 
+> **Note:** Until the scientific Python stack fully supports NumPy 2, this package
+> requires a NumPy version below 2.0. Ensure that your environment has
+> `numpy<2` installed to avoid binary compatibility errors.
+
 ## Quick start
 ```bash
 kinship-vis results.genome \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 ]
 dependencies = [
   "pandas>=1.5",
-  "numpy>=1.23",
+  "numpy>=1.23,<2",
   "networkx>=3.0",
   "matplotlib>=3.5",
   "plotly>=5.0"


### PR DESCRIPTION
## Summary
- restrict numpy dependency to <2 to avoid ABI errors with modules built against numpy 1.x
- document the numpy<2 requirement in the README

## Testing
- `pip install 'numpy<2' -q` *(fails: Could not find a version that satisfies the requirement numpy<2 (ProxyError: Tunnel connection failed: 403 Forbidden))*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1fe5f923883268683fb3f64d4e7e5