### PR TITLE
Constrain numpy and plotly versions for compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ Visualize pairwise kinship results (PLINK `.genome` or KING `.kin0`) as componen
 pip install kinship-vis
 ```
 
+> **Note:** Until the scientific Python stack fully supports NumPy 2 and Plotly 6, this package
+> requires `numpy<2` and `plotly<6`. Ensure that your environment uses these versions to avoid compatibility issues.
+
 ## Quick start
 ```bash
 kinship-vis results.genome \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,10 +22,10 @@ classifiers = [
 ]
 dependencies = [
   "pandas>=1.5",
-  "numpy>=1.23",
+  "numpy>=1.23,<2",
   "networkx>=3.0",
   "matplotlib>=3.5",
-  "plotly>=5.0"
+  "plotly>=5,<6"
 ]
 
 [project.urls]


### PR DESCRIPTION
## Summary
- restrict plotly dependency to <6 alongside existing numpy<2 pin
- document the numpy<2 and plotly<6 requirements in the README

## Testing
- `pip install -e .` *(fails: Could not find a version that satisfies the requirement hatchling>=1.26 (ProxyError: Cannot connect to proxy))*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b1fe5f923883268683fb3f64d4e7e5