### PR TITLE
Restrict plotly dependency to below 6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
   "numpy>=1.23,<2",
   "networkx>=3.0",
   "matplotlib>=3.5",
-  "plotly>=5.0"
+  "plotly>=5,<6"
 ]
 
 [project.urls]


### PR DESCRIPTION
## Summary
- restrict plotly dependency to version <6 to avoid conflicts with packages such as hail

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b2007c8bf0832696f3829c0f780e71